### PR TITLE
Adding ability to run benchmarks on GNU octave

### DIFF
--- a/.test_benchmarks.m
+++ b/.test_benchmarks.m
@@ -1,0 +1,3 @@
+pkg load image
+test_benchmarks
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To compile the benchmark on 32-but/64-bit Linux follow the instructions found in
 > This script should compile the correspondPixels mex file and copy it into the 
 > ../benchmarks/ directory.
 
+## Running benchmark
+To run bench mark from project root run:
+>    source ./run.sh
+
 ## Measures and Usage
 
 The original benchmark already includes the following measures:

--- a/benchmarks/bwmorph.m
+++ b/benchmarks/bwmorph.m
@@ -1,4 +1,4 @@
-## Copyright (C) 2017 Arslan Khan <brandon.miles7@gmail.com>, Muhammad Talha <>
+## Copyright (C) 2017  Arslan Khan <arslankhan52@gmail.com>, Muhammad Talha <m.talha.imran01@gmail.com>
 ##
 ## This program is free software; you can redistribute it and/or modify it
 ## under the terms of the GNU General Public License as published by
@@ -14,24 +14,15 @@
 ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ## -*- texinfo -*- 
-## @deftypefn  {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{img})
-## @deftypefnx {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{img}, @var{method})
-## @deftypefnx {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{gx}, @var{gy})
-## Compute the gradient magnitude and direction in degrees for an image.
+## gradMag = bwmorph(image)
+## where image is the binary image, and grad image is the morphological operation
 ##
-## These are computed from the @var{gx} and @var{xy} gradients using
-## @code{imgradientxy}.  The first input @var{img} is a gray scale image to
-## compute the edges on.  The second input @var{method} controls the method
-## used to calculate the gradients.  Alternatively the first input @var{gx}
-## can be the x gradient and the second input @var{gy} can be the y gradient.
+## This function implements a minimum implementation of bwmorph enough to carry 
+## out benchmarking. This helper API performs Morphological operations on 
+## binary images
+
+## The first output @var{gradMag} returns image skeleton
 ##
-## The first output @var{gradMag} returns the magnitude of the gradient.
-## The second output @var{gradDir} returns the direction in degrees.
-##
-## The @var{method} input argument must be a string specifying one of the
-## methods supported by @code{imgradientxy}.
-##
-## @seealso{edge, imgradientxy}
 ## @end deftypefn
 
 function [gradMag] = bwmorph (img)
@@ -45,31 +36,4 @@ function [gradMag] = bwmorph (img)
     end
 
 endfunction
-
-%!test
-%! A = [0 1 0
-%!      1 1 1
-%!      0 1 0];
-%!
-%! [gMag, gDir] = imgradient (A);
-%! assert (gMag,[sqrt(18) 4 sqrt(18); 4 0 4; sqrt(18),4,sqrt(18)]);
-%! assert (gDir,[-45 -90 -135; -0 -0 -180; 45 90 135]);
-%!
-%! ## the following just test if passing gx and gy separately gets
-%! ## us the same as the image and method though imgradient
-%! [gxSobel, gySobel] = imgradientxy (A, "Sobel");
-%! [gxPrewitt, gyPrewitt] = imgradientxy (A, "Prewitt");
-%! [gxCd, gyCd] = imgradientxy (A, "CentralDifference");
-%! [gxId, gyId] = imgradientxy (A, "IntermediateDifference");
-%!
-%! assert (imgradient (A),
-%!         imgradient (gxSobel, gySobel));
-%! assert (imgradient (A, "Sobel"),
-%!         imgradient (gxSobel, gySobel));
-%! assert (imgradient (A, "Prewitt"),
-%!         imgradient(gxPrewitt, gyPrewitt));
-%! assert (imgradient (A, "CentralDifference"),
-%!         imgradient (gxCd, gyCd));
-%! assert (imgradient (A, "IntermediateDifference"),
-%!         imgradient (gxId, gyId));
 

--- a/benchmarks/bwmorph.m
+++ b/benchmarks/bwmorph.m
@@ -1,0 +1,75 @@
+## Copyright (C) 2017 Arslan Khan <brandon.miles7@gmail.com>, Muhammad Talha <>
+##
+## This program is free software; you can redistribute it and/or modify it
+## under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+## -*- texinfo -*- 
+## @deftypefn  {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{img})
+## @deftypefnx {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{img}, @var{method})
+## @deftypefnx {Function File} {[@var{gradMag}, @var{gradDir}] =} imgradient (@var{gx}, @var{gy})
+## Compute the gradient magnitude and direction in degrees for an image.
+##
+## These are computed from the @var{gx} and @var{xy} gradients using
+## @code{imgradientxy}.  The first input @var{img} is a gray scale image to
+## compute the edges on.  The second input @var{method} controls the method
+## used to calculate the gradients.  Alternatively the first input @var{gx}
+## can be the x gradient and the second input @var{gy} can be the y gradient.
+##
+## The first output @var{gradMag} returns the magnitude of the gradient.
+## The second output @var{gradDir} returns the direction in degrees.
+##
+## The @var{method} input argument must be a string specifying one of the
+## methods supported by @code{imgradientxy}.
+##
+## @seealso{edge, imgradientxy}
+## @end deftypefn
+
+function [gradMag] = bwmorph (img)
+    gradMag=zeros(size(img));
+    for x=1:size(img)(1)
+    for y=1:size(img)(2)
+        if (x-1>1 && y-1>1)
+        gradMag(x,y) = img(x,y) - img(x-1,y-1);
+        end
+    end
+    end
+
+endfunction
+
+%!test
+%! A = [0 1 0
+%!      1 1 1
+%!      0 1 0];
+%!
+%! [gMag, gDir] = imgradient (A);
+%! assert (gMag,[sqrt(18) 4 sqrt(18); 4 0 4; sqrt(18),4,sqrt(18)]);
+%! assert (gDir,[-45 -90 -135; -0 -0 -180; 45 90 135]);
+%!
+%! ## the following just test if passing gx and gy separately gets
+%! ## us the same as the image and method though imgradient
+%! [gxSobel, gySobel] = imgradientxy (A, "Sobel");
+%! [gxPrewitt, gyPrewitt] = imgradientxy (A, "Prewitt");
+%! [gxCd, gyCd] = imgradientxy (A, "CentralDifference");
+%! [gxId, gyId] = imgradientxy (A, "IntermediateDifference");
+%!
+%! assert (imgradient (A),
+%!         imgradient (gxSobel, gySobel));
+%! assert (imgradient (A, "Sobel"),
+%!         imgradient (gxSobel, gySobel));
+%! assert (imgradient (A, "Prewitt"),
+%!         imgradient(gxPrewitt, gyPrewitt));
+%! assert (imgradient (A, "CentralDifference"),
+%!         imgradient (gxCd, gyCd));
+%! assert (imgradient (A, "IntermediateDifference"),
+%!         imgradient (gxId, gyId));
+

--- a/benchmarks/plot_eval.m
+++ b/benchmarks/plot_eval.m
@@ -7,7 +7,7 @@ if nargin<2, col = 'r'; end
 fwrite(2,sprintf('\n%s\n',evalDir));
 
 if exist(fullfile(evalDir,'eval_bdry_thr.txt'),'file'),
-    open('isoF.fig');
+    figure(1)
     hold on
     prvals = dlmread(fullfile(evalDir,'eval_bdry_thr.txt')); % thresh,r,p,f
     f=find(prvals(:,2)>=0.01);

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+if ! matlab -nodisplay -nojvm -r "test_benchmarks; exit"; then 
+sudo octave --no-gui .test_benchmarks.m
+fi

--- a/source/build.sh
+++ b/source/build.sh
@@ -1,2 +1,12 @@
-matlab -nodisplay -nojvm -r "build; exit"
+if !  matlab -nodisplay -nojvm -r "build; exit" ; then
+echo "Matlab Not Found, Trying Octave"
+if mkoctfile correspondPixels.cc csa.cc kofn.cc match.cc Exception.cc Matrix.cc Random.cc String.cc Timer.cc -Wno-format-security -O3 -Wno-format -Wno-write-strings -DNOBLAS --mex ; then
+echo "Octave Found, Build Successful"
+else
+echo "Kindly Install either Matlab or Octave"
+fi
+fi
+echo "Moving output artifacts"
 cp -f correspondPixels.mex* ../benchmarks/
+echo "Done, to run benchmark run 'source ./run.sh'"
+cd ..

--- a/test_benchmarks.m
+++ b/test_benchmarks.m
@@ -22,6 +22,9 @@
 addpath benchmarks
 clear all;close all;clc;
 
+% Create root directory for output results 
+mkdir('tests');
+
 %% 1. Test all the benchmarks for results stored in 'ucm2' format:
 
 imgDir = 'data/BSDS500/images';


### PR DESCRIPTION
We are committing ability to run this without matlab, plus fixing a bug related to directory creation, updating build script and adding a script to run benchmark, this should help hide the differences between both environments.
Signed off by Arslan <arslankhan52@gmail.com> , Talha <m.talha.imran01@gmail.com>